### PR TITLE
feat(bcompile): implement gcc wrapper command bcompile

### DIFF
--- a/src/commands/basic-gcc/bcompile.c
+++ b/src/commands/basic-gcc/bcompile.c
@@ -1,0 +1,67 @@
+#include "bcompile.h"
+
+const char *GCC_PATH = "/usr/bin/gcc";
+const char *GCC_WALL_FLAG = "-Wall";
+const char *GCC_WEXTRA_FLAG = "-Wextra";
+const char *GCC_WERROR_FLAG = "-Werror";
+const char *GCC_OUTPUT_FLAG = "-o";
+const int GCC_REQ_ARG_COUNT = 5;
+
+int basic_gcc_compile(char** args) {
+    int pid;
+    int child_status;
+
+    pid = fork();
+
+    //  parent process
+    if (pid) {
+        printf("Waiting for child (%d)\n", pid);
+        pid = wait(&child_status);
+        printf("Child (%d) finished\n", pid);
+    } 
+
+    // child process
+    else {
+
+        if(args[1] == NULL) {
+            fprintf(stderr, "Usage: bcompile <source_files>\n");
+            exit(1);
+        }
+
+        char* exec_name = strdup(args[1]);
+        char* dot = strrchr(exec_name, '.');
+
+        if (dot != NULL && strcmp(dot, ".c") == 0) {
+            *dot = '\0';
+        }
+
+        // count src files
+        int i = 1;
+        while (args[i] != NULL) i++;
+        int source_count = i - 1;
+
+        // prepare argument array
+        int max_args = GCC_REQ_ARG_COUNT + source_count;
+        char *gcc_args[max_args];
+
+        int j = 0;
+        gcc_args[j++] = (char *)GCC_PATH;
+        gcc_args[j++] = (char *)GCC_OUTPUT_FLAG;
+        gcc_args[j++] = exec_name;
+
+        // source files
+        for (int k = 1; k <= source_count; ++k) {
+            gcc_args[j++] = args[k];
+        }
+
+        // flags
+        gcc_args[j++] = (char *)GCC_WALL_FLAG;
+        gcc_args[j++] = (char *)GCC_WEXTRA_FLAG;
+        gcc_args[j] = NULL;
+
+        execvp(GCC_PATH, gcc_args);
+    }
+
+    return 0;
+
+}

--- a/src/commands/basic-gcc/bcompile.h
+++ b/src/commands/basic-gcc/bcompile.h
@@ -1,0 +1,20 @@
+#ifndef BCOMPILE_H
+#define BCOMPILE_H
+
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+
+extern const char *GCC_PATH;
+extern const char *GCC_WALL_FLAG;
+extern const char *GCC_WEXTRA_FLAG;
+extern const char *GCC_WERROR_FLAG;
+extern const char *GCC_OUTPUT_FLAG;
+extern const int GCC_REQ_ARG_COUNT;
+
+int basic_gcc_compile(char** args);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <sys/wait.h>
 #include "commands/cd/change_directory.h"
+#include "commands/basic-gcc/bcompile.h"
 
 #define BUFFER_SIZE 1024
 #define MAX_ARGS 64
@@ -47,6 +48,11 @@ int main(int argc, char* argv[]) {
 
         if (strcmp(args[0], "cd") == 0) {
             change_dir(args[1]);
+            continue;
+        }
+
+        if (strcmp(args[0], "bcompile") == 0) {
+            basic_gcc_compile(args);
             continue;
         }
 


### PR DESCRIPTION
Implemented bcompile command which wraps gcc to make it simpler to use for basic use cases when the user wants to quickly compile something without the headache of remembering how to structure the gcc command. 

Usage:
bcompile source1.c source2.c -> gcc -o source1 source1.c source2.c -Wall -Wextra

The name of the executable is the name of the first source file (source1)