### PR TITLE
feat(command_history): add key press support

### DIFF
--- a/src/include/cmd_history.h
+++ b/src/include/cmd_history.h
@@ -1,0 +1,19 @@
+#ifndef CMD_HISTORY_H
+#define CMD_HISTORY_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern const int MAX_HISTORY;
+extern int history_count;
+extern int history_index;
+
+int add_history(const char* command);
+const char *get_older_history();
+const char *get_newer_history();
+void reset_history_nav();
+void reset_history_index();
+void free_history();
+
+#endif

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1,0 +1,14 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#define BACKSPACE_KEY 127
+#define ESCAPE_CHAR '\x1b'
+#define UP_ARROW_KEY 'A'
+#define DOWN_ARROW_KEY 'B'
+#define CLEAR_LINE "\33[2K\r"
+#define STR_TOKEN_DELIM " \t\n"
+
+void enable_raw_mode(struct termios *original);
+void disable_raw_mode(struct termios *original);
+
+#endif

--- a/src/miloshell.c
+++ b/src/miloshell.c
@@ -1,27 +1,31 @@
 
 #include <unistd.h>
 #include <sys/types.h>
+#include <termios.h>
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
 #include <sys/wait.h>
+
 #include "include/cd.h"
 #include "include/bcompile.h"
+#include "include/utils.h"
+#include "include/cmd_history.h"
 
-#define BUFFER_SIZE 1024
 #define MAX_ARGS 64
+#define BUFFER_SIZE 1024
 
 // Function to parse the input buffer into arguments
 void parse_input(char** args, char* input) {
 
     int i = 0;
-    char *token = strtok(input, " \t\n");
+    char *token = strtok(input, STR_TOKEN_DELIM);
 
     while (token != NULL && i < MAX_ARGS - 1) {
         args[i++] = token;
-        token = strtok(NULL, " \t\n");
+        token = strtok(NULL, STR_TOKEN_DELIM);
     }
 
     args[i] = NULL;
@@ -34,17 +38,80 @@ int main(int argc, char* argv[]) {
     char *args[MAX_ARGS];
     int child_status;
     pid_t pid;
+    struct termios original_term;
+
+    enable_raw_mode(&original_term);
 
     while(1) {
 
         printf("$");
-        fgets(buffer, BUFFER_SIZE, stdin);
-        parse_input(args, buffer);
+        fflush(stdout);
 
-        // Skip empty input
-        if (args[0] == NULL) {
+        int buf_pos = 0;
+        memset(buffer, 0, BUFFER_SIZE);  // Clear buffer, set to zeros
+        reset_history_index();
+
+        while (1) {
+            char c;
+            if (read(STDIN_FILENO, &c, 1) != 1) continue;
+
+            if (c == '\n') {
+                buffer[buf_pos] = '\0';
+                printf("\n");
+                break;
+            } else if (c == BACKSPACE_KEY) {
+                fflush(stdout);
+                if (buf_pos > 0) {
+                    buf_pos--;
+                    buffer[buf_pos] = '\0';
+                    printf("\b \b");
+                    fflush(stdout);
+                }
+            } else if (c == ESCAPE_CHAR) {
+                char seq[2];
+                if (read(STDIN_FILENO, &seq[0], 1) != 1) continue;
+                if (read(STDIN_FILENO, &seq[1], 1) != 1) continue;
+
+                if (seq[0] == '[') {
+                    const char *hist_cmd = NULL;
+
+                    // up arrow
+                    if (seq[1] == UP_ARROW_KEY) {
+                        hist_cmd = get_older_history();
+                    } 
+                    
+                    // down arrow
+                    else if (seq[1] == DOWN_ARROW_KEY) {
+                        hist_cmd = get_newer_history();
+                    }
+
+                    if (hist_cmd) {
+                        printf(CLEAR_LINE "$%s", hist_cmd); // clear line and print command
+                        fflush(stdout);
+                        strncpy(buffer, hist_cmd, BUFFER_SIZE - 1);
+                        buffer[BUFFER_SIZE - 1] = '\0';
+                        buf_pos = strlen(buffer);
+                    }
+                }
+            } else if (c < 32 || c > 126) {
+                // Ignore control characters except for backspace and up down arrows
+                continue;
+            }
+            else {
+                if (buf_pos < BUFFER_SIZE - 1) {
+                    buffer[buf_pos++] = c;
+                    write(STDOUT_FILENO, &c, 1);
+                    fflush(stdout);
+                }
+            }
+        }
+
+        if (buffer[0] == '\0') {
             continue;
         }
+
+        add_history(buffer);
+        parse_input(args, buffer);
 
         if (strcmp(args[0], "cd") == 0) {
             change_dir(args[1]);
@@ -63,10 +130,8 @@ int main(int argc, char* argv[]) {
         pid = fork();
 
         // parent process
-        if (pid){
-            printf("Waiting for child (%d)\n", pid);
-            pid = wait(&child_status);
-            printf("Child (%d) finished\n", pid);
+        if (pid) { 
+            pid = wait(&child_status); 
         } 
 
         // child process
@@ -76,7 +141,7 @@ int main(int argc, char* argv[]) {
                 exit(127);
             }
         }
-
     }
+    disable_raw_mode(&original_term); 
     return 0;
 }

--- a/src/shortcuts/cmd_history.c
+++ b/src/shortcuts/cmd_history.c
@@ -1,0 +1,67 @@
+#include "../include/cmd_history.h"
+
+#define MAX_HISTORY 100
+
+static char* cmd_history[MAX_HISTORY];
+int history_count = 0;
+int history_index = 0;
+
+/**
+ * Adds a command to the history.
+ * Returns 0 on success, -1 if history is full.
+ */
+int add_history(const char* command) {
+    if (history_count < MAX_HISTORY) {
+        cmd_history[history_count++] = strdup(command);
+        history_index = history_count;
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+/**
+ * Retrieves the previous command in history.
+ * If at the beginning of history, returns NULL. Up Arrow key
+ */
+const char *get_older_history() {
+    if (history_index > 0) {
+        return cmd_history[--history_index];
+    } else if (history_index == 0) {
+        return cmd_history[history_index];
+    }
+    return NULL;
+}
+
+/**
+ * Retrieves the next command in history.
+ * If at the end of history, returns the last command. Down Arrow key
+ */
+const char *get_newer_history() {
+    if (history_index < history_count - 1) {
+        return cmd_history[++history_index];
+    } else if (history_index == history_count - 1) {
+        return cmd_history[history_index];
+    }
+    return NULL;
+}
+
+/**
+ * Resets the history count and index.
+ */
+void reset_history_nav() {
+
+    history_count = 0;
+    history_index = 0;
+}
+
+void reset_history_index() {
+    history_index = history_count;
+}
+
+void free_history() {
+    for (int i = 0; i < history_count; ++i) {
+        free(cmd_history[i]);
+    }
+}
+

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -1,0 +1,15 @@
+#include <unistd.h>
+#include <termios.h>
+#include "../include/utils.h"
+
+void enable_raw_mode(struct termios *original) {
+    struct termios raw;
+    tcgetattr(STDIN_FILENO, original);
+    raw = *original;
+    raw.c_lflag &= ~(ICANON | ECHO); // Disable canonical mode and echo
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw);
+}
+
+void disable_raw_mode(struct termios *original) {
+    tcsetattr(STDIN_FILENO, TCSAFLUSH, original);
+}


### PR DESCRIPTION
Changes
- Refactored the shell options so it reads character by character instead of waiting for when user presses enter. This is so key press support can be added
- Backspace functionality added
- up and down arrow functionality added
- command history added that can be browsed with up and down arrow